### PR TITLE
升级项目：构建系统现代化及功能增强 (v0.1.1 → v1.0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+tortoise-svn-*.vsix

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 tortoise-svn-*.vsix
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
     },
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
-    },
-    "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
+    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,24 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile",
+                "--loglevel",
+                "silent"
+            ],
+            "isBackground": true,
+            "problemMatcher": "$tsc-watch",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        }
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 0.1.3
+* remove `SVN ... (Select Path)` command and its related keybinding (`alt+s s`)
+
 ### Version 0.1.2
 * add `SVN Diff -c Last` command for both workspace directory and active file
     - retrieves the last changed revision via `svn info` and opens TortoiseSVN diff between `lastRev-1` and `lastRev`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 0.1.2
+* add `SVN Diff -c Last` command for both workspace directory and active file
+    - retrieves the last changed revision via `svn info` and opens TortoiseSVN diff between `lastRev-1` and `lastRev`
+
 ### Version 0.1.1
 * when user don't set `TortoiseSVN.tortoiseSVNProcExePath`, get the `TortoiseProc.exe` path from registry 
 * postpone check `TortoiseProc.exe` path until command execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Version 1.0.1
+* rename `File: SVN Diff` command to `SVN Diff File`
+* add `SVN Diff WorkSpace` to explorer context menu
+* add `SVN Diff File` to editor context menu
+* add sort order for context menu items
+* remove `diff` option from Select Action dropdown list
+* rename `svn diff -c last` label to `svn diff` in Select Action dropdown list
+
 ### Version 0.1.3
 * remove `SVN ... (Select Path)` command and its related keybinding (`alt+s s`)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-README
+## README
 
 tortoise-svn is a simple extension for VSCode to use TortoiseSVN.
 
@@ -50,16 +50,15 @@ please specify the correct path by setting property `TortoiseSVN.tortoiseSVNProc
     - Apply to the select file/directory when trigger this command by use explorer context menu.   
     - Apply to the workspace when trigger this command by use command panel(F1/ctrl+shift+p).   
 
-* `SVN ... (Select Path)` : show a `dropdown` to select target `directory` or `file`, then show a new `dropdown` to select TortoiseSVN action to execute.
-
 ### Keybindings
 
-* `alt+s u` : "Workspace: SVN Update"
-* `alt+s c` : "Workspace: SVN Commit"
-* `alt+s l` : "Workspace: SVN Log"
-* `alt+s r` : "Workspace: SVN Revert"
-* `alt+s d` : "Workspace: SVN Diff"
-* `alt+s m` : "SVN ... (Select Path)"
+* `alt+s c` : "SVN Commit WorkSpace"
+* `alt+s u` : "SVN Update WorkSpace"
+* `alt+s a` : "SVN Add WorkSpace" (also "File: SVN Add" when editor has focus)
+* `alt+s l` : "SVN Log WorkSpace" (also "File: SVN Log" when editor has focus)
+* `alt+s r` : "SVN Revert WorkSpace" (also "File: SVN Revert" when editor has focus)
+* `alt+s d` : "SVN Diff WorkSpace" (also "File: SVN Diff" when editor has focus)
+* `alt+s s` : "SVN ... (Select Action)"
 
 ## Extension Settings
 
@@ -70,6 +69,9 @@ This extension contributes the following settings:
 * `TortoiseSVN.showPath.exclude` : specify `glob pattern` to exclude files and folders. exclude will disable when specify a empty array.
 
 ## Change Log
+### Version 0.1.3
+* remove `SVN ... (Select Path)` command and its related keybinding (`alt+s m`)
+
 ### Version 0.1.2
 * add `SVN Diff -c Last` command for both workspace directory and active file
     - retrieves the last changed revision via `svn info` and opens TortoiseSVN diff between `lastRev-1` and `lastRev`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-#README
+README
 
 tortoise-svn is a simple extension for VSCode to use TortoiseSVN.
+
+> GitHub Repository: [TangYanxin/vscode-tortoise-svn](https://github.com/TangYanxin/vscode-tortoise-svn)
 
 ## Features
 
@@ -27,6 +29,7 @@ please specify the correct path by setting property `TortoiseSVN.tortoiseSVNProc
 * `Workspace: SVN Diff` : open TortoiseSVN `diff` window
 * `Workspace: SVN Lock` : open TortoiseSVN `lock` window
 * `Workspace: SVN Unlock` : open TortoiseSVN `unlock` window
+* `Workspace: SVN Diff -c Last` : diff the workspace against its last committed revision
 
 #### For the active file which open in text editor and has focus
 * `File: SVN Update` : open TortoiseSVN `update` window
@@ -39,6 +42,7 @@ please specify the correct path by setting property `TortoiseSVN.tortoiseSVNProc
 * `File: SVN Diff` : open TortoiseSVN `diff` window
 * `File: SVN Lock` : open TortoiseSVN `lock` window
 * `File: SVN Unlock` : open TortoiseSVN `unlock` window
+* `File: SVN Diff -c Last` : diff the active file against its last committed revision
 
 #### Others
 * `SVN ... (Select Action)` : show a `dropdown` to select TortoiseSVN action to execute.
@@ -66,6 +70,10 @@ This extension contributes the following settings:
 * `TortoiseSVN.showPath.exclude` : specify `glob pattern` to exclude files and folders. exclude will disable when specify a empty array.
 
 ## Change Log
+### Version 0.1.2
+* add `SVN Diff -c Last` command for both workspace directory and active file
+    - retrieves the last changed revision via `svn info` and opens TortoiseSVN diff between `lastRev-1` and `lastRev`
+
 ### Version 0.1.1
 * when user don't set `TortoiseSVN.tortoiseSVNProcExePath`, get the `TortoiseProc.exe` path from registry 
 * postpone check `TortoiseProc.exe` path until command execution

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ please specify the correct path by setting property `TortoiseSVN.tortoiseSVNProc
 * `File: SVN Cleanup` : open TortoiseSVN `cleanup` window
 * `File: SVN Add` : open TortoiseSVN `add` window
 * `File: SVN Blame` : open TortoiseSVN `Blame` window
-* `File: SVN Diff` : open TortoiseSVN `diff` the active file against its last committed revision window
+* `SVN Diff File` : open TortoiseSVN `diff` window
 * `File: SVN Lock` : open TortoiseSVN `lock` window
 * `File: SVN Unlock` : open TortoiseSVN `unlock` window
 
@@ -68,6 +68,14 @@ This extension contributes the following settings:
 * `TortoiseSVN.showPath.exclude` : specify `glob pattern` to exclude files and folders. exclude will disable when specify a empty array.
 
 ## Change Log
+### Version 1.0.1
+* rename `File: SVN Diff` command to `SVN Diff File`
+* add `SVN Diff WorkSpace` to explorer context menu
+* add `SVN Diff File` to editor context menu
+* add sort order for context menu items
+* remove `diff` option from Select Action dropdown list
+* rename `svn diff -c last` label to `svn diff` in Select Action dropdown list
+
 ### Version 0.1.3
 * remove `SVN ... (Select Path)` command and its related keybinding (`alt+s m`)
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ please specify the correct path by setting property `TortoiseSVN.tortoiseSVNProc
 * `File: SVN Cleanup` : open TortoiseSVN `cleanup` window
 * `File: SVN Add` : open TortoiseSVN `add` window
 * `File: SVN Blame` : open TortoiseSVN `Blame` window
-* `File: SVN Diff` : open TortoiseSVN `diff` window
+* `File: SVN Diff` : open TortoiseSVN `diff` the active file against its last committed revision window
 * `File: SVN Lock` : open TortoiseSVN `lock` window
 * `File: SVN Unlock` : open TortoiseSVN `unlock` window
-* `File: SVN Diff -c Last` : diff the active file against its last committed revision
 
 #### Others
 * `SVN ... (Select Action)` : show a `dropdown` to select TortoiseSVN action to execute.
@@ -57,7 +56,7 @@ please specify the correct path by setting property `TortoiseSVN.tortoiseSVNProc
 * `alt+s a` : "SVN Add WorkSpace" (also "File: SVN Add" when editor has focus)
 * `alt+s l` : "SVN Log WorkSpace" (also "File: SVN Log" when editor has focus)
 * `alt+s r` : "SVN Revert WorkSpace" (also "File: SVN Revert" when editor has focus)
-* `alt+s d` : "SVN Diff WorkSpace" (also "File: SVN Diff" when editor has focus)
+* `alt+s d` : "SVN Diff WorkSpace" (also "SVN Diff File" when editor has focus)
 * `alt+s s` : "SVN ... (Select Action)"
 
 ## Extension Settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,172 @@
+{
+  "name": "tortoise-svn",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tortoise-svn",
+      "version": "0.1.1",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "glob": "^7.0.6"
+      },
+      "devDependencies": {
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^25.6.0",
+        "@types/vscode": "^1.116.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.60.0"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.116.0"
       }
     },
     "node_modules/@types/mocha": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "tortoise-svn",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tortoise-svn",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "glob": "^7.0.6"
-      },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tortoise-svn",
-  "version": "0.1.3",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tortoise-svn",
-      "version": "0.1.3",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tortoise-svn",
   "displayName": "TortoiseSVN",
   "description": "tortoise-svn is a simple extension for VSCode to use TortoiseSVN.",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "publisher": "fantasytyx",
   "author": {
     "name": "TangYaxin",
@@ -31,47 +31,47 @@
     "commands": [
       {
         "command": "workspace tortoise-svn update",
-        "title": "Workspace: SVN Update"
+        "title": "SVN Update WorkSpace"
       },
       {
         "command": "workspace tortoise-svn commit",
-        "title": "Workspace: SVN Commit"
+        "title": "SVN Commit WorkSpace"
       },
       {
         "command": "workspace tortoise-svn log",
-        "title": "Workspace: SVN Log"
+        "title": "SVN Log WorkSpace"
       },
       {
         "command": "workspace tortoise-svn revert",
-        "title": "Workspace: SVN Revert"
+        "title": "SVN Revert WorkSpace"
       },
       {
         "command": "workspace tortoise-svn cleanup",
-        "title": "Workspace: SVN Cleanup"
+        "title": "SVN Cleanup WorkSpace"
       },
       {
         "command": "workspace tortoise-svn add",
-        "title": "Workspace: SVN Add"
+        "title": "SVN Add WorkSpace"
       },
       {
         "command": "workspace tortoise-svn diff",
-        "title": "Workspace: SVN Diff"
+        "title": "SVN Diff WorkSpace"
       },
       {
         "command": "workspace tortoise-svn lock",
-        "title": "Workspace: SVN Lock"
+        "title": "SVN Lock WorkSpace"
       },
       {
         "command": "workspace tortoise-svn unlock",
-        "title": "Workspace: SVN Unlock"
+        "title": "SVN Unlock WorkSpace"
       },
       {
         "command": "workspace tortoise-svn merge",
-        "title": "Workspace: SVN Merge"
+        "title": "SVN Merge WorkSpace"
       },
       {
         "command": "workspace tortoise-svn diff-last",
-        "title": "Workspace: SVN Diff -c Last"
+        "title": "SVN Diff -c Last WorkSpace"
       },
       {
         "command": "file tortoise-svn update",
@@ -120,10 +120,6 @@
       {
         "command": "tortoise-svn ...",
         "title": "SVN ... (Select Action)"
-      },
-      {
-        "command": "tortoise-svn ...(select path)",
-        "title": "SVN ... (Select Path)"
       }
     ],
     "menus": {
@@ -139,10 +135,6 @@
         {
           "command": "tortoise-svn ...",
           "group": "tortoise-svn"
-        },
-        {
-          "command": "tortoise-svn ...(select path)",
-          "group": "tortoise-svn"
         }
       ],
       "editor/context": [
@@ -156,10 +148,6 @@
         },
         {
           "command": "tortoise-svn ...",
-          "group": "tortoise-svn"
-        },
-        {
-          "command": "tortoise-svn ...(select path)",
           "group": "tortoise-svn"
         }
       ]
@@ -235,10 +223,6 @@
       {
         "command": "tortoise-svn ...",
         "key": "alt+s s"
-      },
-      {
-        "command": "tortoise-svn ...(select path)",
-        "key": "alt+s m"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
         "title": "Workspace: SVN Merge"
       },
       {
+        "command": "workspace tortoise-svn diff-last",
+        "title": "Workspace: SVN Diff -c Last"
+      },
+      {
         "command": "file tortoise-svn update",
         "title": "File: SVN Update"
       },
@@ -100,6 +104,10 @@
       {
         "command": "file tortoise-svn diff",
         "title": "File: SVN Diff"
+      },
+      {
+        "command": "file tortoise-svn diff-last",
+        "title": "File: SVN Diff -c Last"
       },
       {
         "command": "file tortoise-svn lock",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/fantacytyx/vscode-tortoise-svn/issues"
   },
   "engines": {
-    "vscode": "^1.4.0"
+    "vscode": "^1.116.0"
   },
   "categories": [
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -243,13 +243,14 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./"
   },
   "devDependencies": {
-    "typescript": "^1.8.5",
-    "vscode": "^0.11.0"
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^25.6.0",
+    "@types/vscode": "^1.116.0",
+    "typescript": "^5.0.0"
   },
   "dependencies": {
     "glob": "^7.0.6"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tortoise-svn",
   "displayName": "TortoiseSVN",
   "description": "tortoise-svn is a simple extension for VSCode to use TortoiseSVN.",
-  "version": "0.1.3",
+  "version": "1.0.1",
   "publisher": "fantasytyx",
   "author": {
     "name": "TangYaxin",
@@ -103,7 +103,7 @@
       },
       {
         "command": "file tortoise-svn diff",
-        "title": "File: SVN Diff"
+        "title": "SVN Diff File"
       },
       {
         "command": "file tortoise-svn diff-last",
@@ -126,29 +126,37 @@
       "explorer/context": [
         {
           "command": "workspace tortoise-svn update",
-          "group": "tortoise-svn"
+          "group": "tortoise-svn@1"
         },
         {
           "command": "workspace tortoise-svn commit",
-          "group": "tortoise-svn"
+          "group": "tortoise-svn@2"
+        },
+        {
+          "command": "workspace tortoise-svn diff",
+          "group": "tortoise-svn@3"
         },
         {
           "command": "tortoise-svn ...",
-          "group": "tortoise-svn"
+          "group": "tortoise-svn@4"
         }
       ],
       "editor/context": [
         {
           "command": "workspace tortoise-svn update",
-          "group": "tortoise-svn"
+          "group": "tortoise-svn@1"
         },
         {
           "command": "workspace tortoise-svn commit",
-          "group": "tortoise-svn"
+          "group": "tortoise-svn@2"
+        },
+        {
+          "command": "file tortoise-svn diff",
+          "group": "tortoise-svn@3"
         },
         {
           "command": "tortoise-svn ...",
-          "group": "tortoise-svn"
+          "group": "tortoise-svn@4"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as glob from 'glob';
 
-const DIRECTORY_ACTIONS: string[] = ['update', 'commit', 'revert', 'cleanup', 'log', 'add', 'diff', 'lock', 'unlock', 'merge'];
-const FILE_ACTIONS: string[] = ['update', 'commit', 'revert', 'cleanup', 'log', 'add', 'blame', 'diff', 'lock', 'unlock'];
+const DIRECTORY_ACTIONS: string[] = ['update', 'commit', 'revert', 'cleanup', 'log', 'add', 'diff', 'diff-last', 'lock', 'unlock', 'merge'];
+const FILE_ACTIONS: string[] = ['update', 'commit', 'revert', 'cleanup', 'log', 'add', 'blame', 'diff', 'diff-last', 'lock', 'unlock'];
 
 interface SvnQuickPickItem extends vscode.QuickPickItem {
     action?: string;
@@ -170,7 +170,7 @@ class UriInfo implements UriInfo {
         }
         return quickPickItems.map<SvnQuickPickItem>(action => {
             return {
-                label: 'svn ' + action,
+                label: action === 'diff-last' ? 'svn diff -c last' : 'svn ' + action,
                 description: this.path,
                 path: this.path,
                 action: action
@@ -223,7 +223,36 @@ class TortoiseCommand {
         // todo: Send line number with blame command. https://tortoisesvn.net/docs/release/TortoiseSVN_en/tsvn-automation.html
         return `"${this.tortoiseSVNProcExePath}" /command:${action} /path:"${this._getTargetPath(fileUri)}" /closeonend:${closeonend}`;
     }
+    execDiffLast(fileUri: string) {
+        const targetPath = this._getTargetPath(fileUri);
+        child_process.exec(`svn info -r HEAD "${targetPath}"`, (error, stdout, stderr) => {
+            if (error) {
+                vscode.window.showErrorMessage(`svn info failed: ${stderr}`);
+                return;
+            }
+            const match = stdout.match(/Last Changed Rev:\s*(\d+)/);
+            if (!match) {
+                vscode.window.showErrorMessage('Cannot get Last Changed Rev from svn info.');
+                return;
+            }
+            const lastRev = parseInt(match[1], 10);
+            const prevRev = lastRev - 1;
+            const cmd = `"${this.tortoiseSVNProcExePath}" /command:diff /path:"${targetPath}" /startrev:${prevRev} /endrev:${lastRev}`;
+            child_process.exec(cmd, (err, so, se) => {
+                if (err && !this.tortoiseSVNProcExePathIsExist()) {
+                    vscode.window.showErrorMessage(`Setting "TortoiseSVN.tortoiseSVNProcExePath" is invalid. Please specify a correct one, then restart VSCode.`);
+                    console.log(err);
+                    console.log(so);
+                    console.log(se);
+                }
+            });
+        });
+    }
     exec(action: string, fileUri: string) {
+        if (action === 'diff-last') {
+            this.execDiffLast(fileUri);
+            return;
+        }
         let allFileSave;
         // Can't revert unsaved changes.
         if (action === "revert") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import * as child_process from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as glob from 'glob';
 
 const DIRECTORY_ACTIONS: string[] = ['update', 'commit', 'revert', 'cleanup', 'log', 'add', 'diff', 'diff-last', 'lock', 'unlock', 'merge'];
 const FILE_ACTIONS: string[] = ['update', 'commit', 'revert', 'cleanup', 'log', 'add', 'blame', 'diff', 'diff-last', 'lock', 'unlock'];
@@ -77,64 +76,9 @@ export function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(disposableNeedChoose);
 
-    let disposableDropdown = vscode.commands.registerCommand('tortoise-svn ...(select path)', (uri: vscode.Uri) => {
-        // exec every time on command trigger
-        getQuickPickItemsFromDir(vscode.workspace.rootPath).then(quickPickItems => {
-            return vscode.window.showQuickPick<SvnQuickPickItem>(quickPickItems);
-        }).then(path => {
-            if (!path) {
-                return;
-            }
-            let uriInfo = new UriInfo(path.path);
-            let actionQuickPickItems = uriInfo.getActionQuickPickItem()
-            vscode.window.showQuickPick<any>(actionQuickPickItems).then((action) => {
-                if (action) {
-                    tortoiseCommand.exec(action.action, action.path);
-                }
-            });
-        });
-        context.subscriptions.push(disposableDropdown);
-    });
 }
 
 
-/**
- * 获取目录下的所有文件夹和文件的绝对路径
- * 
- * @param {string} dirPath
- * @param {Function} callback
- */
-function getQuickPickItemsFromDir(dirPath: string): Promise<SvnQuickPickItem[]> {
-    return new Promise<SvnQuickPickItem[]>((resolve, reject) => {
-        let quickPickItems: SvnQuickPickItem[] = [{
-            label: dirPath,
-            description: dirPath,
-            path: dirPath
-        }];
-        let ignore: any = vscode.workspace.getConfiguration('TortoiseSVN').get('showPath.exclude');
-        let options: any = { cwd: dirPath, mark: true };
-        if (Object.prototype.toString.call(ignore) === '[object Array]' && ignore.length > 0) {
-            options.ignore = ignore;
-        }
-        glob('**', options, (err, paths) => {
-            if (err) throw err;
-            paths.forEach(file => {
-                var lastSep = file.lastIndexOf('/') + 1;
-                if (lastSep === file.length) {
-                    lastSep = 0;
-                }
-                quickPickItems.push({
-                    label: file.substring(lastSep),
-                    description: file.substr(0, lastSep),
-                    path: path.join(vscode.workspace.rootPath, file)
-                });
-            });
-
-            resolve(quickPickItems);
-        });
-    });
-
-}
 
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,9 +112,9 @@ class UriInfo implements UriInfo {
         } else if (this.isDirectory) {
             quickPickItems = DIRECTORY_ACTIONS;
         }
-        return quickPickItems.map<SvnQuickPickItem>(action => {
+        return quickPickItems.filter(a => a !== 'diff').map<SvnQuickPickItem>(action => {
             return {
-                label: action === 'diff-last' ? 'svn diff -c last' : 'svn ' + action,
+                label: action === 'diff-last' ? 'svn diff' : 'svn ' + action,
                 description: this.path,
                 path: this.path,
                 action: action

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es2020",
+        "lib": ["es2020"],
+        "types": ["node", "vscode", "mocha"],
         "outDir": "out",
-        "noLib": true,
         "sourceMap": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "strict": false
     },
     "exclude": [
         "node_modules",

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,1 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />
+// Node.js types are provided by @types/node

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,1 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />
+// VS Code types are provided by @types/vscode


### PR DESCRIPTION
## 概述

将 vscode-tortoise-svn 扩展从 v0.1.1 升级至 v1.0.1，涵盖构建系统现代化、命令重命名、新增功能及代码清理。

## 主要变更

### 🔧 构建系统升级
- TypeScript `1.8.5` → `5.x`，编译目标 `es5` → `es2020`
- VS Code 引擎 `^1.4.0` → `^1.116.0`
- 替换旧版 `vscode` npm 包为 `@types/vscode` / `@types/node` / `@types/mocha`
- 构建脚本从 `node ./node_modules/vscode/bin/compile` 改为 `tsc`
- tasks.json 从 v0.1.0 格式升级至 v2.0.0
- 激活事件从 `*` 改为 `onStartupFinished`

### ✨ 新功能
- 新增 `SVN Diff -c Last` 命令（工作区 + 文件），通过 `svn info` 获取最后修改版本并打开 TortoiseSVN diff
- 右键菜单增加排序（`tortoise-svn@1` ~ `@4`）
- 资源管理器和编辑器右键菜单新增 `SVN Diff` 入口

### 🔄 命令重命名
- `Workspace: SVN *` → `SVN * WorkSpace`
- `File: SVN Diff` → `SVN Diff File`
- Select Action 下拉列表中 `diff` 选项移除，`diff-last` 显示为 `svn diff`

### 🗑️ 移除
- 移除 `SVN ... (Select Path)` 命令及相关快捷键 `alt+s m`
- 移除 `glob` 模块依赖及 `getQuickPickItemsFromDir` 函数

### 📝 文档
- 更新 README 和 CHANGELOG 至 v1.0.1
- 新增 .gitignore 规则（vsix、settings.json）

## 版本记录
- **v0.1.2**: 新增 `SVN Diff -c Last` 命令
- **v0.1.3**: 移除 `SVN ... (Select Path)` 命令
- **v1.0.1**: 命令重命名、菜单排序、构建系统升级